### PR TITLE
Handle search adapter updates in MainActivity

### DIFF
--- a/project/app/src/main/java/com/iven/musicplayergo/MainActivity.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/MainActivity.kt
@@ -125,6 +125,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var mSelectedArtistSongs: MutableList<Music>
     private lateinit var mSelectedArtistAlbums: List<Album>
     private var mNavigationArtist: String? = "unknown"
+    private var mFilteredArtists: List<String>? = null
 
     //player
     private lateinit var mMediaPlayerHolder: MediaPlayerHolder
@@ -206,7 +207,14 @@ class MainActivity : AppCompatActivity() {
             val searchView = search.actionView as SearchView
 
             searchView.setIconifiedByDefault(false)
-            Utils.setupSearch(searchView, mArtistsAdapter, mArtists, mIndicatorFastScrollerView)
+            Utils.setupSearch(searchView, mArtists, mIndicatorFastScrollerView, onResultsChanged = { newResults ->
+                mFilteredArtists = if (newResults.isEmpty()) {
+                    null
+                } else {
+                    newResults
+                }
+                mArtistsAdapter.setArtists(mFilteredArtists ?: mArtists)
+            })
         }
         return super.onCreateOptionsMenu(menu)
     }
@@ -525,7 +533,7 @@ class MainActivity : AppCompatActivity() {
                 mIndicatorFastScrollerView.setupWithRecyclerView(
                     mArtistsRecyclerView,
                     { position ->
-                        val item = mArtists[position] // Get your model object
+                        val item = (mFilteredArtists ?: mArtists)[position] // Get your model object
                         // or fetch the section at [position] from your database
 
                         FastScrollItemIndicator.Text(

--- a/project/app/src/main/java/com/iven/musicplayergo/Utils.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/Utils.kt
@@ -10,7 +10,6 @@ import android.widget.Toast
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
-import com.iven.musicplayergo.adapters.ArtistsAdapter
 import com.pranavpandey.android.dynamic.toasts.DynamicToast
 import com.reddit.indicatorfastscroll.FastScrollerView
 
@@ -28,16 +27,16 @@ object Utils {
     @JvmStatic
     fun setupSearch(
         searchView: SearchView,
-        artistsAdapter: ArtistsAdapter,
         artists: List<String>,
-        indicator: FastScrollerView
+        indicator: FastScrollerView,
+        onResultsChanged: (List<String>) -> Unit
     ) {
 
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
 
             override
             fun onQueryTextChange(newText: String): Boolean {
-                processQuery(newText, artistsAdapter, artists)
+                onResultsChanged(processQuery(newText, artists))
                 return false
             }
 
@@ -55,7 +54,7 @@ object Utils {
 
     @SuppressLint("DefaultLocale")
     @JvmStatic
-    private fun processQuery(query: String, artistsAdapter: ArtistsAdapter, artists: List<String>) {
+    private fun processQuery(query: String, artists: List<String>): List<String> {
         // in real app you'd have it instantiated just once
         val results = mutableListOf<String>()
 
@@ -70,9 +69,7 @@ object Utils {
             e.printStackTrace()
         }
 
-        if (results.size > 0) {
-            artistsAdapter.setQueryResults(results)
-        }
+        return results
     }
 
     //get theme

--- a/project/app/src/main/java/com/iven/musicplayergo/adapters/ArtistsAdapter.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/adapters/ArtistsAdapter.kt
@@ -19,13 +19,13 @@ class ArtistsAdapter(
     RecyclerView.Adapter<ArtistsAdapter.ArtistsHolder>() {
 
     var onArtistClick: ((String?) -> Unit)? = null
-    private var mArtists = artists
+    private var mArtists: List<String> = artists
 
     init {
         Collections.sort(mArtists, String.CASE_INSENSITIVE_ORDER)
     }
 
-    fun setQueryResults(artists: MutableList<String>) {
+    fun setArtists(artists: List<String>) {
         mArtists = artists
         notifyDataSetChanged()
     }


### PR DESCRIPTION
When making a search query, `artistsAdapter` is given a new filtered list of artists, but the fast scroller is still reading from `mArtists`, which isn't filtered. This changes `processQuery` to return the filtered list so that MainActivity can handle giving it to the adapter as well as the fast scroller.