### PR TITLE
Swipe to remove from queue / loved

### DIFF
--- a/project/app/src/main/java/com/iven/musicplayergo/adapters/LovedSongsAdapter.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/adapters/LovedSongsAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.afollestad.materialdialogs.MaterialDialog
 import com.iven.musicplayergo.MusicRepository
@@ -99,6 +100,10 @@ class LovedSongsAdapter(
                     return@setOnLongClickListener true
                 }
             }
+
         }
+
+
     }
 }
+


### PR DESCRIPTION
Songs can now be swiped away from the list list of loved and queued. This seemed easier than holding each one and accepting the pop-up dialog.

Songs can still be removed by long clicking them.

here's the debug APK if you want to try it: https://send.firefox.com/download/81d46cdbf781db46/#gn5sg_V-odnhV8910WawMQ 