### PR TITLE
Toogle loved status

### DIFF
--- a/project/app/src/main/java/com/iven/musicplayergo/adapters/LovedSongsAdapter.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/adapters/LovedSongsAdapter.kt
@@ -63,14 +63,7 @@ class LovedSongsAdapter(
             val subtitle = itemView.findViewById<TextView>(R.id.subtitle)
 
             title.text = lovedSong?.title
-            duration.text = context.getString(
-                R.string.loved_song_subtitle,
-                lovedSong?.startFrom?.toLong()?.toFormattedDuration(
-                    isAlbum = false,
-                    isSeekBar = false
-                ),
-                lovedSong?.duration?.toFormattedDuration(isAlbum = false, isSeekBar = false)
-            ).toSpanned()
+            duration.text = lovedSong?.duration?.toFormattedDuration(isAlbum = false, isSeekBar = false)
             subtitle.text =
                 context.getString(R.string.artist_and_album, lovedSong?.artist, lovedSong?.album)
 

--- a/project/app/src/main/java/com/iven/musicplayergo/extensions/MusicExts.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/extensions/MusicExts.kt
@@ -93,3 +93,15 @@ fun Music.toSavedMusic(playerPosition: Int, isPlayingFromFolder: Boolean) =
         album,
         isPlayingFromFolder
     )
+
+fun Music.toSavedMusicWithoutPosition(isPlayingFromFolder: Boolean) =
+    SavedMusic(
+        artist,
+        title,
+        displayName,
+        year,
+        0,
+        duration,
+        album,
+        isPlayingFromFolder
+    )

--- a/project/app/src/main/java/com/iven/musicplayergo/helpers/DialogHelper.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/helpers/DialogHelper.kt
@@ -257,7 +257,7 @@ object DialogHelper {
 
                     when (it.itemId) {
                         R.id.loved_songs_add -> {
-                            ListsHelper.addToLovedSongs(
+                            ListsHelper.addOrRemoveFromLovedSongs(
                                 context,
                                 song,
                                 0,

--- a/project/app/src/main/java/com/iven/musicplayergo/helpers/ListsHelper.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/helpers/ListsHelper.kt
@@ -6,9 +6,7 @@ import android.view.Menu
 import android.view.MenuItem
 import com.iven.musicplayergo.GoConstants
 import com.iven.musicplayergo.R
-import com.iven.musicplayergo.extensions.toFormattedDuration
-import com.iven.musicplayergo.extensions.toSavedMusic
-import com.iven.musicplayergo.extensions.toToast
+import com.iven.musicplayergo.extensions.toSavedMusicWithoutPosition
 import com.iven.musicplayergo.goPreferences
 import com.iven.musicplayergo.models.Music
 import java.util.*
@@ -128,7 +126,7 @@ object ListsHelper {
     }
 
     @JvmStatic
-    fun addToLovedSongs(
+    fun addOrRemoveFromLovedSongs(
         context: Context,
         song: Music?,
         playerPosition: Int,
@@ -137,23 +135,19 @@ object ListsHelper {
         val lovedSongs =
             if (goPreferences.lovedSongs != null) goPreferences.lovedSongs else mutableListOf()
 
-        val songToSave = song?.toSavedMusic(playerPosition, isPlayingFromFolder)
+        val songToSave = song?.toSavedMusicWithoutPosition(isPlayingFromFolder)
 
         songToSave?.let { savedSong ->
-            if (!lovedSongs?.contains(savedSong)!!) {
+            if (lovedSongs?.contains(savedSong)!!) {
+                lovedSongs.remove(
+                    savedSong
+                )
+            }else {
                 lovedSongs.add(
                     savedSong
                 )
-                context.getString(
-                    R.string.loved_song_added,
-                    savedSong.title,
-                    savedSong.startFrom.toLong().toFormattedDuration(
-                        isAlbum = false,
-                        isSeekBar = false
-                    )
-                ).toToast(context)
-                goPreferences.lovedSongs = lovedSongs
             }
+            goPreferences.lovedSongs = lovedSongs
         }
     }
 }

--- a/project/app/src/main/java/com/iven/musicplayergo/ui/MainActivity.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/ui/MainActivity.kt
@@ -548,7 +548,7 @@ class MainActivity : AppCompatActivity(), UIControlInterface {
                 mNowPlayingControlsBinding.npRepeat.setOnClickListener { setRepeat() }
 
                 mNowPlayingExtendedControlsBinding.npLove.setOnClickListener {
-                    ListsHelper.addToLovedSongs(
+                    ListsHelper.addOrRemoveFromLovedSongs(
                         this@MainActivity,
                         mMediaPlayerHolder.currentSong.first,
                         mMediaPlayerHolder.playerPosition,
@@ -591,8 +591,33 @@ class MainActivity : AppCompatActivity(), UIControlInterface {
                         }
                     }
                 }
+                updateNowPlayingLovedIcon(context)
             }
         }
+    }
+
+    private fun updateNowPlayingLovedIcon(context: Context) {
+        if (this::mMediaPlayerHolder.isInitialized && this::mNowPlayingExtendedControlsBinding.isInitialized) {
+            mMediaPlayerHolder.currentSong.first.let {
+                val isLoved = isInLovedSongs(it!!)
+                val lovedSongsButtonColor = if (isLoved)
+                    R.color.red.decodeColor(context) else mResolvedDisabledIconsColor
+                ThemeHelper.updateIconTint(
+                    mNowPlayingExtendedControlsBinding.npLove,
+                    lovedSongsButtonColor
+                )
+            }
+        }
+    }
+
+    private fun isInLovedSongs(song: Music): Boolean {
+        val lovedSongs = goPreferences.lovedSongs
+        if (lovedSongs != null) {
+            val convertedSong =
+                song.toSavedMusicWithoutPosition(mMediaPlayerHolder.isPlayingFromFolder)
+            return lovedSongs.contains(convertedSong)
+        }
+        return false
     }
 
     private fun saveSongToPref() {
@@ -642,6 +667,8 @@ class MainActivity : AppCompatActivity(), UIControlInterface {
             mPlayerControlsPanelBinding.lovedSongsButton,
             lovedSongsButtonColor
         )
+
+        updateNowPlayingLovedIcon(this)
     }
 
     private fun restorePlayerStatus() {
@@ -786,6 +813,7 @@ class MainActivity : AppCompatActivity(), UIControlInterface {
         }
 
         updatePlayingStatus(true)
+        updateNowPlayingLovedIcon(this)
     }
 
     fun openPlayingArtistAlbum(view: View) {
@@ -868,6 +896,7 @@ class MainActivity : AppCompatActivity(), UIControlInterface {
             if (mMediaPlayerHolder.isSongRestoredFromPrefs) mMediaPlayerHolder.isSongRestoredFromPrefs =
                 false
         }
+        updateNowPlayingLovedIcon(this)
     }
 
     private fun setRepeat() {


### PR DESCRIPTION
The loved button of the nowPlaying pop-up can now toggle is a song is added or not. I also added a visual feedback to it if the current song is loved.

This needed to remove the start position of loved song since this lead to inconsistencies (the earth would not turn red if the currently playing song didn't match play position of when is was marked as loved at the exact second). This also allowed strange behavior like having two time the same song in the loved list (each one with a different start time).

If you still want to be able to add songs with a certain start time i can re-add this feature on a long click of the loved button.

Here the APK to test it: https://send.firefox.com/download/845e3f84116b326c/#vH7myS5WkS9SODYoZWNxBw
