### PR TITLE
Polish full_description.txt – removed some lines

### DIFF
--- a/fastlane/metadata/android/pl/full_description.txt
+++ b/fastlane/metadata/android/pl/full_description.txt
@@ -44,8 +44,6 @@
 - Pauza/wznowienie odtwarzania, gdy słuchawki są podłączane/odłączane
 - Proste zarządzanie funkcją skupienia audio
 
-– Polskie tłumaczenie aplikacji :)
-
 # Chcesz pomóc w tłumaczeniu aplikacji?
 
 Przeczytaj (w języku angielskim): https://github.com/enricocid/Music-Player-GO/issues/114 :)


### PR DESCRIPTION
Removed some unnecessary lines, so whole text is equal in lines to the original (English) translation, which should fix its visibility (it's now not visible, only short_description.txt is visible in Play Store).