### PR TITLE
Improve/Optimize Coil Usage

### DIFF
--- a/project/app/src/main/java/com/iven/musicplayergo/GoApp.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/GoApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import coil.ImageLoader
 import coil.ImageLoaderFactory
+import coil.request.CachePolicy
 import com.iven.musicplayergo.helpers.ThemeHelper
 
 val goPreferences: GoPreferences by lazy {
@@ -24,7 +25,7 @@ class GoApp : Application(), ImageLoaderFactory {
 
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)
-            .bitmapPoolingEnabled(false)
+            .diskCachePolicy(CachePolicy.DISABLED)
             .crossfade(true)
             .error(R.drawable.album_art)
             .build()

--- a/project/app/src/main/java/com/iven/musicplayergo/GoApp.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/GoApp.kt
@@ -2,13 +2,15 @@ package com.iven.musicplayergo
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
+import coil.ImageLoader
+import coil.ImageLoaderFactory
 import com.iven.musicplayergo.helpers.ThemeHelper
 
 val goPreferences: GoPreferences by lazy {
     GoApp.prefs
 }
 
-class GoApp : Application() {
+class GoApp : Application(), ImageLoaderFactory {
 
     companion object {
         lateinit var prefs: GoPreferences
@@ -18,5 +20,13 @@ class GoApp : Application() {
         super.onCreate()
         prefs = GoPreferences(applicationContext)
         AppCompatDelegate.setDefaultNightMode(ThemeHelper.getDefaultNightMode(applicationContext))
+    }
+
+    override fun newImageLoader(): ImageLoader {
+        return ImageLoader.Builder(this)
+            .bitmapPoolingEnabled(false)
+            .crossfade(true)
+            .error(R.drawable.album_art)
+            .build()
     }
 }

--- a/project/app/src/main/java/com/iven/musicplayergo/fragments/DetailsFragment.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/fragments/DetailsFragment.kt
@@ -721,7 +721,11 @@ class DetailsFragment : Fragment(R.layout.fragment_details), SearchView.OnQueryT
     }
 
     private fun loadCoverIntoTarget(song: Music?, target: ImageView) {
-        target.load(song?.albumId?.toAlbumArtURI())
+        if (goPreferences.isCovers) {
+            target.load(song?.albumId?.toAlbumArtURI())
+        } else {
+            target.setImageResource(R.drawable.album_art)
+        }
     }
 
     fun hasToUpdate(selectedArtistOrFolder: String?) : Boolean {

--- a/project/app/src/main/java/com/iven/musicplayergo/fragments/DetailsFragment.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/fragments/DetailsFragment.kt
@@ -2,7 +2,6 @@ package com.iven.musicplayergo.fragments
 
 import android.animation.Animator
 import android.content.Context
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -12,7 +11,6 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
-import androidx.core.graphics.drawable.toBitmap
 import androidx.core.os.bundleOf
 import androidx.core.text.parseAsHtml
 import androidx.fragment.app.Fragment
@@ -20,9 +18,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import coil.ImageLoader
 import coil.load
-import coil.request.ImageRequest
 import com.afollestad.recyclical.datasource.dataSourceOf
 import com.afollestad.recyclical.setup
 import com.afollestad.recyclical.withItem
@@ -725,7 +721,7 @@ class DetailsFragment : Fragment(R.layout.fragment_details), SearchView.OnQueryT
     }
 
     private fun loadCoverIntoTarget(song: Music?, target: ImageView) {
-        target.load(song?.albumId?.getCoverFromURI())
+        target.load(song?.albumId?.toAlbumArtURI())
     }
 
     fun hasToUpdate(selectedArtistOrFolder: String?) : Boolean {

--- a/project/app/src/main/java/com/iven/musicplayergo/fragments/MusicContainersListFragment.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/fragments/MusicContainersListFragment.kt
@@ -62,23 +62,6 @@ class MusicContainersListFragment : Fragment(R.layout.fragment_music_container_l
     private var sIsFastScroller = false
     private val sIsFastScrollerVisible get() = sIsFastScroller && mSorting != GoConstants.DEFAULT_SORTING
 
-    /**
-     * This is the job for all coroutines started by this ViewModel.
-     * Cancelling this job will cancel all coroutines started by this ViewModel.
-     */
-    private val mLoadCoverJob = SupervisorJob()
-
-    private val mLoadCoverHandler = CoroutineExceptionHandler { _, exception ->
-        exception.printStackTrace()
-    }
-
-    private val mLoadCoverIoDispatcher = Dispatchers.IO + mLoadCoverJob + mLoadCoverHandler
-    private val mLoadCoverIoScope = CoroutineScope(mLoadCoverIoDispatcher)
-
-    private val sIsCovers get() = goPreferences.isCovers
-    private lateinit var mImageLoader: ImageLoader
-    private var mAlbumArt: Bitmap? = null
-
     override fun onAttach(context: Context) {
         super.onAttach(context)
 
@@ -92,13 +75,6 @@ class MusicContainersListFragment : Fragment(R.layout.fragment_music_container_l
             mUIControlInterface = activity as UIControlInterface
         } catch (e: ClassCastException) {
             e.printStackTrace()
-        }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        if (sLaunchedByAlbumView && sIsCovers) {
-            mLoadCoverJob.cancel()
         }
     }
 
@@ -132,15 +108,6 @@ class MusicContainersListFragment : Fragment(R.layout.fragment_music_container_l
     }
 
     private fun finishSetup() {
-
-        if (sLaunchedByAlbumView) {
-            mImageLoader = ImageLoader.Builder(requireActivity())
-                    .bitmapPoolingEnabled(false)
-                    .crossfade(true)
-                    .build()
-            mAlbumArt = ContextCompat.getDrawable(requireActivity(), R.drawable.album_art)?.toBitmap()
-        }
-
         _musicContainerListBinding?.artistsFoldersRv?.let { rv ->
 
             // setup{} is an extension method on RecyclerView
@@ -153,27 +120,14 @@ class MusicContainersListFragment : Fragment(R.layout.fragment_music_container_l
                     withItem<String, ContainersAlbumViewHolder>(R.layout.containers_album_item) {
                         onBind(::ContainersAlbumViewHolder) { _, item ->
                             // ContainersAlbumViewHolder is `this` here
-                            if (sIsCovers) {
-                                val request = ImageRequest.Builder(requireActivity())
-                                        .data(mMusicViewModel.deviceMusicByAlbum?.get(item)?.get(0)?.albumId?.getCoverFromURI())
-                                        .target(
-                                                onSuccess = { result ->
-                                                    // Handle the successful result.
-                                                    albumCover.load(result)
-                                                },
-                                                onError = {
-                                                    albumCover.load(mAlbumArt)
-                                                }
-                                        )
-                                        .build()
+                            if (goPreferences.isCovers) {
+                                val uri = mMusicViewModel.deviceMusicByAlbum?.get(item)?.get(0)?.albumId?.getCoverFromURI()
 
-                                mLoadCoverIoScope.launch {
-                                    withContext(mLoadCoverIoDispatcher) {
-                                        mImageLoader.enqueue(request)
-                                    }
+                                albumCover.load(uri) {
+
                                 }
                             } else {
-                                albumCover.load(mAlbumArt)
+                                albumCover.setImageResource(R.drawable.album_art)
                             }
 
                             title.text = item

--- a/project/app/src/main/java/com/iven/musicplayergo/fragments/MusicContainersListFragment.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/fragments/MusicContainersListFragment.kt
@@ -1,19 +1,15 @@
 package com.iven.musicplayergo.fragments
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.*
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
-import androidx.core.graphics.drawable.toBitmap
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
-import coil.ImageLoader
 import coil.load
-import coil.request.ImageRequest
 import com.afollestad.recyclical.datasource.emptyDataSource
 import com.afollestad.recyclical.setup
 import com.afollestad.recyclical.withItem
@@ -121,7 +117,7 @@ class MusicContainersListFragment : Fragment(R.layout.fragment_music_container_l
                         onBind(::ContainersAlbumViewHolder) { _, item ->
                             // ContainersAlbumViewHolder is `this` here
                             if (goPreferences.isCovers) {
-                                val uri = mMusicViewModel.deviceMusicByAlbum?.get(item)?.get(0)?.albumId?.getCoverFromURI()
+                                val uri = mMusicViewModel.deviceMusicByAlbum?.get(item)?.get(0)?.albumId?.toAlbumArtURI()
 
                                 albumCover.load(uri) {
 

--- a/project/app/src/main/java/com/iven/musicplayergo/models/Music.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/models/Music.kt
@@ -11,7 +11,7 @@ data class Music(
     val displayName: String?,
     val duration: Long,
     val album: String?,
-    val albumId: Long?,
+    val albumId: Long,
     val relativePath: String?,
     val id: Long?,
     val launchedBy: String,

--- a/project/app/src/main/java/com/iven/musicplayergo/models/Music.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/models/Music.kt
@@ -11,7 +11,7 @@ data class Music(
     val displayName: String?,
     val duration: Long,
     val album: String?,
-    val albumId: Long,
+    val albumId: Long?,
     val relativePath: String?,
     val id: Long?,
     val launchedBy: String,

--- a/project/app/src/main/java/com/iven/musicplayergo/player/MediaPlayerHolder.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/player/MediaPlayerHolder.kt
@@ -266,7 +266,7 @@ class MediaPlayerHolder(private val playerService: PlayerService) :
 
         fun updateCover(builder: MediaMetadataCompat.Builder, song: Music) {
             builder.putBitmap(METADATA_KEY_ALBUM_ART, if (goPreferences.isCovers) {
-                song.albumId?.getCoverFromPFD(playerService)
+                song.albumId.getCoverFromPFD(playerService)
             } else {
                 null
             })

--- a/project/app/src/main/java/com/iven/musicplayergo/player/MediaPlayerHolder.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/player/MediaPlayerHolder.kt
@@ -298,6 +298,8 @@ class MediaPlayerHolder(private val playerService: PlayerService) :
                         METADATA_KEY_ALBUM_ART,
                         ContextCompat.getDrawable(playerService, R.drawable.album_art
                     )?.toBitmap())
+
+                    playerService.getMediaSession().setMetadata(build())
                 }
             } else {
                 playerService.getMediaSession().setMetadata(build())

--- a/project/app/src/main/java/com/iven/musicplayergo/player/MusicNotificationManager.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/player/MusicNotificationManager.kt
@@ -140,7 +140,7 @@ class MusicNotificationManager(private val playerService: PlayerService) {
         mediaPlayerHolder.currentSong.first?.let { song ->
 
             val cover = if (goPreferences.isCovers) {
-                song.albumId?.getCoverFromPFD(playerService) ?: mAlbumArt
+                song.albumId.getCoverFromPFD(playerService) ?: mAlbumArt
             } else {
                 mAlbumArt
             }

--- a/project/app/src/main/java/com/iven/musicplayergo/player/MusicNotificationManager.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/player/MusicNotificationManager.kt
@@ -20,7 +20,7 @@ import androidx.core.text.parseAsHtml
 import androidx.media.app.NotificationCompat.MediaStyle
 import com.iven.musicplayergo.GoConstants
 import com.iven.musicplayergo.R
-import com.iven.musicplayergo.extensions.getCoverFromPFD
+import com.iven.musicplayergo.extensions.waitForCover
 import com.iven.musicplayergo.goPreferences
 import com.iven.musicplayergo.helpers.ThemeHelper
 import com.iven.musicplayergo.ui.MainActivity
@@ -59,7 +59,7 @@ class MusicNotificationManager(private val playerService: PlayerService) {
         GoConstants.CLOSE_ACTION
     }
 
-    fun createNotification(): Notification {
+    fun createNotification(onCreated: (Notification) -> Unit) {
 
         mNotificationBuilder =
             NotificationCompat.Builder(playerService, GoConstants.NOTIFICATION_CHANNEL_ID)
@@ -78,7 +78,6 @@ class MusicNotificationManager(private val playerService: PlayerService) {
                 openPlayerIntent, 0
         )
 
-        updateNotificationContent()
 
         mNotificationBuilder
             .setContentIntent(contentIntent)
@@ -95,7 +94,10 @@ class MusicNotificationManager(private val playerService: PlayerService) {
                             .setShowActionsInCompactView(1, 2, 3)
             )
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-        return mNotificationBuilder.build()
+
+        updateNotificationContent {
+            onCreated(mNotificationBuilder.build())
+        }
     }
 
     fun cancelNotification() {
@@ -123,8 +125,9 @@ class MusicNotificationManager(private val playerService: PlayerService) {
     fun onHandleNotificationUpdate(isAdditionalActionsChanged: Boolean) {
         if (::mNotificationBuilder.isInitialized) {
             if (!isAdditionalActionsChanged) {
-                updateNotificationContent()
-                updateNotification()
+                updateNotificationContent {
+                    updateNotification()
+                }
             } else {
                 mNotificationActions[0] =
                     getNotificationAction(getFirstAdditionalAction())
@@ -135,28 +138,33 @@ class MusicNotificationManager(private val playerService: PlayerService) {
         }
     }
 
-    fun updateNotificationContent() {
+    fun updateNotificationContent(onDone: (() -> Unit)? = null) {
         val mediaPlayerHolder = playerService.mediaPlayerHolder
+
         mediaPlayerHolder.currentSong.first?.let { song ->
-
-            val cover = if (goPreferences.isCovers) {
-                song.albumId.getCoverFromPFD(playerService) ?: mAlbumArt
-            } else {
-                mAlbumArt
-            }
-
             mNotificationBuilder
                     .setContentText(song.artist)
                     .setContentTitle(
-                            playerService.getString(
+                        playerService.getString(
                                     R.string.song_title_notification,
                                     song.title
                             ).parseAsHtml()
                     )
                     .setSubText(song.album)
-                    .setLargeIcon(cover)
                     .setColorized(true)
                     .setSmallIcon(getNotificationSmallIcon(mediaPlayerHolder))
+
+            if (goPreferences.isCovers) {
+                song.albumId?.waitForCover(playerService) { bitmap ->
+                    mNotificationBuilder.setLargeIcon(bitmap)
+
+                    onDone?.invoke()
+                }
+            } else {
+                mNotificationBuilder.setLargeIcon(mAlbumArt)
+
+                onDone?.invoke()
+            }
         }
     }
 

--- a/project/app/src/main/java/com/iven/musicplayergo/ui/MainActivity.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/ui/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import coil.Coil
 import coil.ImageLoader
 import coil.load
 import coil.request.ImageRequest
@@ -101,21 +102,6 @@ class MainActivity : AppCompatActivity(), UIControlInterface, MediaControlInterf
     private lateinit var mNpCoverBinding: NowPlayingCoverBinding
     private lateinit var mNpControlsBinding: NowPlayingControlsBinding
     private lateinit var mNpExtControlsBinding: NowPlayingExtendedControlsBinding
-
-    /**
-     * This is the job for all coroutines started by this ViewModel.
-     * Cancelling this job will cancel all coroutines started by this ViewModel.
-     */
-    private val mLoadCoverJob = SupervisorJob()
-
-    private val mLoadCoverHandler = CoroutineExceptionHandler { _, exception ->
-        exception.printStackTrace()
-    }
-
-    private val mLoadCoverIoDispatcher = Dispatchers.IO + mLoadCoverJob + mLoadCoverHandler
-    private val mLoadCoverIoScope = CoroutineScope(mLoadCoverIoDispatcher)
-
-    private lateinit var mImageLoader: ImageLoader
 
     private var mSelectedArtistAlbumForNP: Pair<String?, Long?> = Pair("", -1)
 
@@ -212,9 +198,6 @@ class MainActivity : AppCompatActivity(), UIControlInterface, MediaControlInterf
 
     override fun onDestroy() {
         super.onDestroy()
-        if (goPreferences.isCovers) {
-            mLoadCoverJob.cancel()
-        }
         mMusicViewModel.cancel()
         if (isMediaPlayerHolder && !mMediaPlayerHolder.isPlaying && ::mPlayerService.isInitialized && mPlayerService.isRunning && !mMediaPlayerHolder.isSongRestoredFromPrefs) {
             mPlayerService.stopForeground(true)
@@ -1109,34 +1092,12 @@ class MainActivity : AppCompatActivity(), UIControlInterface, MediaControlInterf
     }
 
     private fun loadNpCover(selectedSong: Music) {
-        if (!::mImageLoader.isInitialized) {
-            mImageLoader = ImageLoader.Builder(this)
-                    .bitmapPoolingEnabled(false)
-                    .crossfade(true)
-                    .build()
-        }
-
-        mSelectedArtistAlbumForNP = Pair(selectedSong.artist, selectedSong.albumId)
-        val request = ImageRequest.Builder(this)
-                .data(if (goPreferences.isCovers) {
-                    selectedSong.albumId?.getCoverFromPFD(this) ?: ContextCompat.getDrawable(this, R.drawable.album_art)
-                } else {
-                    ContextCompat.getDrawable(this, R.drawable.album_art)?.toBitmap()
-                })
-                .target(
-                        onSuccess = { result ->
-                            // Handle the successful result.
-                            mNpCoverBinding.npCover.load(result) {
-                                transformations(RoundedCornersTransformation(16.0F))
-                            }
-                        }
-                )
-                .build()
-
-        mLoadCoverIoScope.launch {
-            withContext(mLoadCoverIoDispatcher) {
-                mImageLoader.enqueue(request)
+        if (goPreferences.isCovers) {
+            mNpCoverBinding.npCover.load(selectedSong.albumId.getCoverFromPFD(this)) {
+                transformations(RoundedCornersTransformation(16.0F))
             }
+        } else {
+            mNpCoverBinding.npCover.setImageResource(R.drawable.album_art)
         }
     }
 

--- a/project/app/src/main/java/com/iven/musicplayergo/ui/MainActivity.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/ui/MainActivity.kt
@@ -26,10 +26,7 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import coil.Coil
-import coil.ImageLoader
 import coil.load
-import coil.request.ImageRequest
 import coil.transform.RoundedCornersTransformation
 import com.afollestad.materialdialogs.LayoutMode
 import com.afollestad.materialdialogs.MaterialDialog
@@ -1093,7 +1090,7 @@ class MainActivity : AppCompatActivity(), UIControlInterface, MediaControlInterf
 
     private fun loadNpCover(selectedSong: Music) {
         if (goPreferences.isCovers) {
-            mNpCoverBinding.npCover.load(selectedSong.albumId.getCoverFromURI()) {
+            mNpCoverBinding.npCover.load(selectedSong.albumId?.toAlbumArtURI()) {
                 transformations(RoundedCornersTransformation(16.0F))
             }
         } else {
@@ -1200,7 +1197,7 @@ class MainActivity : AppCompatActivity(), UIControlInterface, MediaControlInterf
 
     override fun onHandleCoverOptionsUpdate() {
         if (isMediaPlayerHolder) {
-            mMediaPlayerHolder.updateMediaSessionMetaData(true)
+            mMediaPlayerHolder.updateMediaSessionMetaData()
         }
         mAlbumsFragment?.onUpdateCoverOption()
     }

--- a/project/app/src/main/java/com/iven/musicplayergo/ui/MainActivity.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/ui/MainActivity.kt
@@ -1093,7 +1093,7 @@ class MainActivity : AppCompatActivity(), UIControlInterface, MediaControlInterf
 
     private fun loadNpCover(selectedSong: Music) {
         if (goPreferences.isCovers) {
-            mNpCoverBinding.npCover.load(selectedSong.albumId.getCoverFromPFD(this)) {
+            mNpCoverBinding.npCover.load(selectedSong.albumId.getCoverFromURI()) {
                 transformations(RoundedCornersTransformation(16.0F))
             }
         } else {


### PR DESCRIPTION
This PR fixes a variety of issues with how coil is used in the app:

- All `ImageLoader` instances have been replaced with a single App-Wide loader, as is recommended by the [Coil Documentation](https://coil-kt.github.io/coil/image_loaders/). This improves efficiency and memory usage since bitmaps can be shared across the app. Most of the shared configuration [Such as the error icon] have been moved to here.
- Replaced most of the custom `ImageRequest` instances with the stock `ImageView.load` method.
- Instead of using a blocking call to get a Bitmap and then passing that to coil, the cover URI is now directly passed to Coil, which then loads it to the ImageView asynchronously. This greatly increases efficiency.
- Used Coil in the `MediaMetadataCompat` & Notification instances [Previously they used blocking calls and didn't share bitmap data with the rest of the app].
- Removed all IO co-routines involved with music loading since Coil already uses them.
- Enabled bitmap pooling, decreasing memory usage since bitmaps can be reused.
- Disabled automatic disc-caching, which decreases app size over time.
- Removed redundant state modifiers [E.G `sIsCovers` instead of just `goPreference.isCovers`]

Overall, this makes image loading both more maintainable and less error-prone compared to before. The most major API change is probably that the `createNotification` is now async, requiring an `onDone` lambda instead of returning the value directly. Other than that this preserves most of the normal architecture. Feel free to raise any concerns with my change.