### PR TITLE
Correct encoding for fastlane translation

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/103.txt
+++ b/fastlane/metadata/android/en-US/changelogs/103.txt
@@ -1,0 +1,1 @@
+- Add Turkish translations (credits: Adem Furkan ÖZCAN)


### PR DESCRIPTION
`Ö` in latin encoding interpreted as UTF-8 (or something of that nature) breaks integration of fastlane translation.
Michal Čihař from Weblate helped find this :)