### PR TITLE
Fix error with control by media player controller apps

### DIFF
--- a/project/app/src/main/java/com/iven/musicplayergo/player/MediaPlayerHolder.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/player/MediaPlayerHolder.kt
@@ -127,9 +127,11 @@ class MediaPlayerHolder:
                     sPlayOnFocusGain =
                         isMediaPlayer && state == GoConstants.PLAYING || state == GoConstants.RESUMED
                 }
-                AudioManager.AUDIOFOCUS_LOSS ->
+                AudioManager.AUDIOFOCUS_LOSS -> {
                     // Lost audio focus, probably "permanently"
                     mCurrentAudioFocusState = AUDIO_NO_FOCUS_NO_DUCK
+                    stopPlaybackService(true)
+                }
             }
             // Update the player state based on the change
             if (isPlaying || state == GoConstants.PAUSED && sRestoreVolume || state == GoConstants.PAUSED && sPlayOnFocusGain) {
@@ -479,9 +481,8 @@ class MediaPlayerHolder:
     }
 
     fun pauseMediaPlayer() {
+        // Do not pause foreground service, we will need to resume likely
         MediaPlayerUtils.safePause(mediaPlayer)
-        ServiceCompat.stopForeground(mPlayerService, ServiceCompat.STOP_FOREGROUND_DETACH)
-        sNotificationForeground = false
         state = GoConstants.PAUSED
         updatePlaybackStatus(updateUI = true)
         mMusicNotificationManager?.run {


### PR DESCRIPTION
Fix error with control by media player controller apps

Try pausing and playing your app multiple times with the media control test app on android 12 and you will experience that your app no longer plays after a while because it is experiencing a ForegroundServiceStartNotAllowedException.

for more details: https://stackoverflow.com/questions/71373928/foregroundservicestartnotallowedexception-for-a-media-player-how-are-we-suppos

also here's a link to a voice controller that can also output the intents to control MusicPlayerGO; unfortunately english only for the moment. https://github.com/hobbycommandline/Hobby-Voice-Command-Line