### PR TITLE
Don't resume playback when headset is connected

### DIFF
--- a/project/app/src/main/java/com/iven/musicplayergo/player/MediaPlayerHolder.kt
+++ b/project/app/src/main/java/com/iven/musicplayergo/player/MediaPlayerHolder.kt
@@ -1049,8 +1049,6 @@ class MediaPlayerHolder:
                             when (intent.getIntExtra("state", -1)) {
                                 // 0 means disconnected
                                 HEADSET_DISCONNECTED -> pauseMediaPlayer()
-                                // 1 means connected
-                                HEADSET_CONNECTED -> resumeMediaPlayer()
                             }
                         }
 


### PR DESCRIPTION
Pausing the playback when headset is disconnected makes sense, but resume when connected does not. Spotify, YouTube, and other apps don't do this. So, it's better to remove it.